### PR TITLE
pre_proccessing: split saved images into training and test images

### DIFF
--- a/src/data2img.py
+++ b/src/data2img.py
@@ -4,6 +4,8 @@ from scipy.misc import toimage, imresize
 
 DATA_OUTPUT_DIR = '../data/img'
 DECOMPOSITION_OUTPUT_DIR = '../data/img/decomposition/'
+DATA_TRAINING_OUTPUT_DIR = '../data/img/train'
+DATA_TEST_OUTPUT_DIR = '../data/img/test'
 
 
 def display_img(data):

--- a/src/data2img.py
+++ b/src/data2img.py
@@ -1,6 +1,8 @@
 import os
 from scipy.misc import toimage, imresize
 
+from format_data import TRAIN_END
+
 
 DATA_OUTPUT_DIR = '../data/img'
 DECOMPOSITION_OUTPUT_DIR = '../data/img/decomposition/'
@@ -26,6 +28,14 @@ def export_image(img_data):
         save_img(img, DATA_OUTPUT_DIR + "/{}/{}.png".format(img[0], i))
     # display an example for demo purpose
     display_img(img_data[2])
+
+
+def export_training_and_test_images(img_data):
+    for i, img in enumerate(img_data):
+        if i <= TRAIN_END:
+            save_img(img, DATA_TRAINING_OUTPUT_DIR + "/{}/{}.png".format(img[0], i))
+        else:
+            save_img(img, DATA_TEST_OUTPUT_DIR + "/{}/{}.png".format(img[0], i))
 
 
 def show_zoomed_image(image_as_list ,zoom_ratio):

--- a/src/face_alignment.py
+++ b/src/face_alignment.py
@@ -20,7 +20,7 @@ def images_to_array(img_dir):
     """
     Takes a directory with images and transform them into pixel arrays
     :param: img_dir is directory of images to transform into pixel values
-    :return: Array of tuples with emotion and numpy.ndarray flattened to one dimensions
+    :return: Array of tuples with emotion and pixel values
     """
     emotion_and_pixels = []
 

--- a/src/face_alignment.py
+++ b/src/face_alignment.py
@@ -1,4 +1,5 @@
 import os
+import pandas as pd
 from scipy.misc import imread
 from data2img import export_training_and_test_images
 
@@ -8,20 +9,36 @@ def align_faces(img_data):
 
     # Run docker script (???) to perform the face alignment
     # and export the aligned images to a new dir
-    return None
+
+    # This seems to be somewhat complicated, but for now one can follow
+    # the instructions on issue #12 for how to create a dir with the aligned faces.
+
+    # There will be csv file (train_aligned.csv) with the end result (aligned faces) available for download.
 
 
 def images_to_array(img_dir):
     """
     Takes a directory with images and transform them into pixel arrays
     :param: img_dir is directory of images to transform into pixel values
-    :return: Array with numpy.ndarrays flattened to one dimensions
+    :return: Array of tuples with emotion and numpy.ndarray flattened to one dimensions
     """
-    pixels = []
-    for root, dir_names, file_names in os.walk(img_dir):
-        for file_name in file_names:
-            file_path = os.path.join(root, file_name)
-            pixel_array = imread(file_path)  # 48*48 array
-            pixels_flat = pixel_array.flatten()  # Flatten 2D array to 1D array
-            pixels.append(pixels_flat)
-    return pixels
+    emotion_and_pixels = []
+
+    for emotion in range(7):
+        for root, dir_names, file_names in os.walk(img_dir + str(emotion)):
+            for file_name in file_names:
+                file_path = os.path.join(root, file_name)
+                pixel_array = imread(file_path)  # 48*48 array
+                pixels_flat = " ".join([str(pixel) for pixel in pixel_array.flatten()])
+                emotion_and_pixels.append((emotion, pixels_flat))
+
+    return emotion_and_pixels
+
+
+def array_to_csv(images_array, output_file):
+    emotion_and_pixels_df = pd.DataFrame(images_array, columns=['emotion', 'pixels'])
+    emotion_and_pixels_df.to_csv(output_file, index=False)
+
+if __name__ == "__main__":
+    imgs_array = images_to_array('../data/img/train_aligned/')
+    array_to_csv(imgs_array, '../data/train_aligned.csv')

--- a/src/face_alignment.py
+++ b/src/face_alignment.py
@@ -1,0 +1,27 @@
+import os
+from scipy.misc import imread
+from data2img import export_training_and_test_images
+
+
+def align_faces(img_data):
+    export_training_and_test_images(img_data)
+
+    # Run docker script (???) to perform the face alignment
+    # and export the aligned images to a new dir
+    return None
+
+
+def images_to_array(img_dir):
+    """
+    Takes a directory with images and transform them into pixel arrays
+    :param: img_dir is directory of images to transform into pixel values
+    :return: Array with numpy.ndarrays flattened to one dimensions
+    """
+    pixels = []
+    for root, dir_names, file_names in os.walk(img_dir):
+        for file_name in file_names:
+            file_path = os.path.join(root, file_name)
+            pixel_array = imread(file_path)  # 48*48 array
+            pixels_flat = pixel_array.flatten()  # Flatten 2D array to 1D array
+            pixels.append(pixels_flat)
+    return pixels


### PR DESCRIPTION
The code changes splits the saved images into training and test images. By doing this we can feed the openface library methods with only training images.
For how to use the openface library to align the faces in the images see below and at issue #12 

# How to use openface

It seems the easiest way to align the faces in the images is to use the _openface_ library, and the easiest way to use _openface_ is via a preconfigured docker image.

## Before we start

Run the modified file `src/data2img.py` to split the images into training and test images.
Pull the docker image which will have openface, dlib and python pre-installed:
```
docker pull bamos/openface
docker run -p 9000:9000 -p 8000:8000 -t -i bamos/openface /bin/bash
cd /root/openface
```

Use the -v flag to make your local folders available inside the docker image. On Mac I do: 
```
docker run -v /Users:/host/Users -p 9000:9000 -p 8000:8000 -t -i bamos/openface /bin/bash
cd /root/openface
```
On Linux, I am not sure how...
Now I can access my files: `ls /host/Users/`
## Step 1.

Make a folder called `./training-images/` inside the openface folder.
```
mkdir training-images
```
## Step 2.
Make a subfolder for each of the expressions. For example:
```
mkdir ./training-images/0/
mkdir ./training-images/1/
```
## Step 3
Copy all local images of each expression into the correct sub-folders. For example:
```
cp -a xxxxxx/facial-expression-recognition/data/img/train/0/. ./training-images/0/
```

## Step 4
Run the openface scripts from inside the openface root directory:

Pose detection and alignment:
```
./util/align-dlib.py ./training-images/ align outerEyesAndNose ./aligned-images/ --size 48
```
This will create a new `./aligned-images/` subfolder with an aligned version of each of the test images.

Now we can copy the contents of `./aligned-images/` back into the project data directory.
```
cp -a aligned-images/. xxxxx/facial-expression-recognition/data/img/train_aligned/
```
We should now have a new directory in our project with the aligned training images at `/facial-expression-recognition/data/img/train_aligned/`
